### PR TITLE
 Comfortably start a new map from within ingame menu.

### DIFF
--- a/code/q3_ui/ui_ingame.c
+++ b/code/q3_ui/ui_ingame.c
@@ -208,7 +208,7 @@ void InGame_MenuInit( void ) {
 	s_ingame.frame.generic.x			= 320-233;//142;
 	s_ingame.frame.generic.y			= 240-166;//118;
 	s_ingame.frame.width				= 466;//359;
-	s_ingame.frame.height				= 332;//256;
+	s_ingame.frame.height				= 356;//256;
 
 	if (UI_MaxSplitView() > 1) {
 		y = 88;

--- a/code/q3_ui/ui_ingame.c
+++ b/code/q3_ui/ui_ingame.c
@@ -55,7 +55,7 @@ INGAME MENU
 #define ID_RESUME				18
 #define ID_TEAMORDERS			19
 #define ID_LOCALPLAYERS			20
-
+#define ID_CREATE				21
 
 typedef struct {
 	menuframework_s	menu;
@@ -66,6 +66,7 @@ typedef struct {
 	menutext_s		server;
 	menutext_s		leave;
 	menutext_s		restart;
+	menutext_s		startnew;
 	menutext_s		addbots;
 	menutext_s		removebots;
 	menutext_s		teamorders;
@@ -147,6 +148,10 @@ void InGame_Event( void *ptr, int notification ) {
 
 	case ID_RESTART:
 		UI_ConfirmMenu( "RESTART ARENA?", 0, InGame_RestartAction );
+		break;
+
+	case ID_CREATE:
+		UI_StartServerMenu( qtrue );
 		break;
 
 	case ID_QUIT:
@@ -325,6 +330,21 @@ void InGame_MenuInit( void ) {
 	}
 
 	y += INGAME_MENU_VERTICAL_SPACING;
+	s_ingame.startnew.generic.type			= MTYPE_PTEXT;
+	s_ingame.startnew.generic.flags			= QMF_CENTER_JUSTIFY|QMF_PULSEIFFOCUS;
+	s_ingame.startnew.generic.x				= 320;
+	s_ingame.startnew.generic.y				= y;
+	s_ingame.startnew.generic.id				= ID_CREATE;
+	s_ingame.startnew.generic.callback		= InGame_Event; 
+	s_ingame.startnew.string					= "START NEW ARENA";
+	s_ingame.startnew.color					= text_big_color;
+	s_ingame.startnew.style					= UI_CENTER|UI_SMALLFONT;
+	if( !trap_Cvar_VariableValue( "sv_running" ) ) {
+		s_ingame.startnew.generic.flags |= QMF_GRAYED;
+	}
+
+
+	y += INGAME_MENU_VERTICAL_SPACING;
 	s_ingame.resume.generic.type			= MTYPE_PTEXT;
 	s_ingame.resume.generic.flags			= QMF_CENTER_JUSTIFY|QMF_PULSEIFFOCUS;
 	s_ingame.resume.generic.x				= 320;
@@ -368,6 +388,7 @@ void InGame_MenuInit( void ) {
 	Menu_AddItem( &s_ingame.menu, &s_ingame.setup );
 	Menu_AddItem( &s_ingame.menu, &s_ingame.server );
 	Menu_AddItem( &s_ingame.menu, &s_ingame.restart );
+	Menu_AddItem( &s_ingame.menu, &s_ingame.startnew );
 	Menu_AddItem( &s_ingame.menu, &s_ingame.resume );
 	Menu_AddItem( &s_ingame.menu, &s_ingame.leave );
 	Menu_AddItem( &s_ingame.menu, &s_ingame.quit );


### PR DESCRIPTION
Allow server to start a new map via in-game menu.

As part of https://github.com/zturtleman/spearmint/issues/48 I highly recommend to make it more comfortable to start and join maps without quitting to main menu.
This is something different than a 'vote' menu, (base Q3 UI has no 'vote' menu at the moment).

Example:
On a LAN game the server (and only the server) can choose a new map and clients don't have to quit to main menu, they are ported to the new map without quitting to main menu anymore (same as if the server started the next map via command/script).