### PR TITLE
BUGFIX: fix bots not jumping out of water in some cases.

### DIFF
--- a/code/game/ai_main.c
+++ b/code/game/ai_main.c
@@ -1408,8 +1408,10 @@ void BotInputToUserCommand(bot_input_t *bi, usercmd_t *ucmd, int delta_angles[3]
 	if (bi->actionflags & ACTION_MOVERIGHT) ucmd->rightmove = 127;
 	//jump/moveup
 	if (bi->actionflags & ACTION_JUMP) ucmd->upmove = 127;
+	if (bi->actionflags & ACTION_MOVEUP) ucmd->upmove = 127;
 	//crouch/movedown
 	if (bi->actionflags & ACTION_CROUCH) ucmd->upmove = -127;
+	if (bi->actionflags & ACTION_MOVEDOWN) ucmd->upmove = -127;
 }
 
 /*


### PR DESCRIPTION
In some cases bots will not be able to jump out of water. The reason is that inside the bot movement logic (see 'BotTravel_WaterJump') they are are using [EA_MoveUp](https://github.com/zturtleman/mint-arena/blob/master/code/game/ai_move.c#L1617) to get out of the water. Unfortunately the actual setting as a bot user command (actionflags) was missing, hence the bot didn't 'know' to move upwards.

NOTE: all idtech3 games using default botai are suffering from this bug. This bug can also be solved by tweaking the 'BotTravel_WaterJump' function (normally this code resides inside the engine, not game code). Fixing this bug inside the mod code seems more accurate, especially because ACTION_MOVEDOWN was also missing. Adding ACTION_MOVEDOWN can help to also fix bots using the 'Flight' powerup.