### PR TITLE
BUGFIX: fix adding bots (starting server via in-game menu).

### DIFF
--- a/code/q3_ui/ui_startserver.c
+++ b/code/q3_ui/ui_startserver.c
@@ -894,7 +894,10 @@ static void ServerOptions_Start( void ) {
 	// the wait commands will allow the dedicated to take effect
 	info = UI_GetArenaInfoByNumber( s_startserver.maplist[ s_startserver.currentmap ]);
 	trap_Cmd_ExecuteText( EXEC_APPEND, va( "wait ; wait ; map %s\n", Info_ValueForKey( info, "map" )));
-
+	// remove bots
+	if ( trap_Cvar_VariableValue("sv_running") ) {
+		trap_Cmd_ExecuteText( EXEC_APPEND, "kickbots\n" );
+	}
 	// add bots
 	trap_Cmd_ExecuteText( EXEC_APPEND, "wait 3\n" );
 	for( n = 1; n < PLAYER_SLOTS; n++ ) {


### PR DESCRIPTION
# This fixes the amount/count of added bots if a new map (server) is started from in-game menu.
In detail, this fixes changes that were made in: https://github.com/zturtleman/mint-arena/commit/5d41663c92e5a0c435a442f04a43aa83d3e056e9.

**The issue:**

If someone starts a new map via in-game 'START NEW ARENA' menu, and the gametype changed, any existing bot will be kept as a connected client and will be added to any new selected bot(s).

**How to reproduce the issue:**
1. Start any map in FFA mode, with one or more bots.
2. Bring up the in-game menu.
3. Select 'START NEW ARENA'.
4. Now select another map in TDM mode, and add a few other bots.
5. After the new gametype/map started, check your scoreboard, the bots from previous FFA match will still exist, although they weren't selected for TDM.

This PR fixes the issue by kicking all the bots if a new map is chosen from in-game menu.

## ***Notes:***
  + I have to admit this is the most simple solution I found, there might be better solutions. For example, bots are always kicked if a new arena is selected now, even if the selected bots didn't change. I think it would make sense to only 'replace' the bots that changed, if nothing changed they shouldn't get kicked.