### PR TITLE
Added Apple Silicon support to Makefile

### DIFF
--- a/code/qcommon/q_platform.h
+++ b/code/qcommon/q_platform.h
@@ -164,6 +164,12 @@ Suite 120, Rockville, Maryland 20850 USA.
 #define idx64 1
 #define ARCH_STRING "x86_64"
 #define Q3_LITTLE_ENDIAN
+#elif defined __aarch64__
+#define ARCH_STRING "arm64"
+#define Q3_LITTLE_ENDIAN
+#ifndef NO_VM_COMPILED
+#define NO_VM_COMPILED
+#endif
 #endif
 
 #define DLL_EXT ".dylib"


### PR DESCRIPTION
Spearmint compiles without any issue on my M3 Pro MBP laptop using the included shell script. When attempting to compile Mint Arena, however, `q_platform.h` does not contain the appropriate definitions for Apple Silicon. This can easily be fixed by applying the appropriate snippets of code from ioquake3's game data Makefile, which does have these necessary definitions.